### PR TITLE
feat: add PR count for each rust-lang repo in last 30 days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "fehler",
  "octocrab",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ name = "github-metrics"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "fehler",
  "octocrab",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 fehler = "1"
 chrono = "0.4"
+url = "2.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ octocrab = "0.9.0"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 fehler = "1"
+chrono = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,7 @@ async fn all_repos(org: &octocrab::orgs::OrgHandler<'_>) -> Vec<octocrab::models
 /// const num_pull_requests = github-metrics::count_pull_requests(octocrab_instance, String::from("rust"));
 ///
 /// println!("'rust-lang/rust' has had {} Pull Requests in the last 30 days!", num_pull_requests);
-///
 /// ```
-///
 #[throws]
 async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> usize {
     let init_page = octo

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Error;
+use chrono::{Duration, Utc};
 use fehler::throws;
+use octocrab::models::pulls::PullRequest;
 use octocrab::models::Repository;
 mod token;
 mod util;
@@ -15,12 +17,53 @@ async fn main() {
     let rust_lang_org = octocrab.orgs("rust-lang");
     let repos: Vec<Repository> = all_repos(&&rust_lang_org).await?;
 
+    println!("#PR,\t\tREPO");
     for repo in &repos {
-        println!("repo: {}", repo.name);
+        let count_prs = count_pull_requests(&octocrab, &repo.name).await?;
+        println!("{},\t{}", count_prs, repo.name);
     }
 }
 
 #[throws]
 async fn all_repos(org: &octocrab::orgs::OrgHandler<'_>) -> Vec<octocrab::models::Repository> {
     util::accumulate_pages(|page| org.list_repos().page(page).send()).await?
+}
+
+#[throws]
+async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> usize {
+    let init_page = octo
+        .pulls("rust-lang", repo_name)
+        .list()
+        .sort(octocrab::params::pulls::Sort::Created)
+        .per_page(100)
+        .send()
+        .await?;
+
+    let thirty_days_ago = Utc::now() - Duration::days(30);
+    let mut pr_count: usize = init_page.items.len();
+    let mut next_page = init_page.next.to_owned();
+
+    let mut count_valid_prs = |page: octocrab::Page<PullRequest>| -> Option<()> {
+        let mut all_valid = true;
+        for pr in page {
+            if pr.created_at < thirty_days_ago {
+                pr_count += 1;
+            } else {
+                all_valid = false;
+            }
+        }
+
+        return if all_valid { Some(()) } else { None };
+    };
+    count_valid_prs(init_page);
+
+    while let Some(page) = octo.get_page::<PullRequest>(&next_page).await? {
+        let copy_next = page.next.to_owned();
+        next_page = match count_valid_prs(page) {
+            Some(_) => copy_next,
+            _ => None,
+        }
+    }
+
+    pr_count
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
 
         return if all_valid { Some(()) } else { None };
     };
-    count_valid_prs(init_page);
+    // count_valid_prs(init_page);
 
     while let Some(page) = octo.get_page::<PullRequest>(&next_page).await? {
         let copy_next = page.next.to_owned();

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,8 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
     };
 
     // run initial page of data through the counter; this might be the only page we have!
-    // note: this is set up this way b/c the `octo.get_page` different is called for all
-    // subsequent pages (rather than `octo.pulls()` which allows us all sorts of good specifications)
+    // NOTE: this is set up this way b/c the `octo.get_page` function is called for all subsequent pages
+    // (rather than `octo.pulls()` which allows us all sorts of good specifications from the starting page)
     count_valid_prs(init_page);
 
     while let Some(page) = octo.get_page::<PullRequest>(&next_page).await? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::Error;
 use chrono::{Duration, Utc};
 use fehler::throws;
-use octocrab::models::pulls::PullRequest;
-use octocrab::models::Repository;
+use octocrab::models::{pulls::PullRequest, Repository};
+use std::option::Option;
+use url::Url;
 mod token;
 mod util;
 
@@ -29,6 +30,28 @@ async fn all_repos(org: &octocrab::orgs::OrgHandler<'_>) -> Vec<octocrab::models
     util::accumulate_pages(|page| org.list_repos().page(page).send()).await?
 }
 
+/// count the number of pull requests created in the last 30 days for the given repository within the [`rust-lang` github organization](https://github.com/rust-lang)
+///
+/// ## Arguments
+///
+/// - `octo` — the instance of `octocrab::Octocrab` that should be used to make any GitHub queries
+/// - `repo_name` — The name of the repository (within GitHub Organization "rust-lang") to count pull-requests for
+///
+/// ## Example
+///
+/// ```
+/// use github-metrics;
+/// use octocrab;
+/// use std::string::String;
+///
+/// let octocrab_instance = octocrab::Octocrab::builder().personal_token("SOME_GITHUB_TOKEN").build()?;
+///
+/// const num_pull_requests = github-metrics::count_pull_requests(octocrab_instance, String::from("rust"));
+///
+/// println!("'rust-lang/rust' has had {} Pull Requests in the last 30 days!", num_pull_requests);
+///
+/// ```
+///
 #[throws]
 async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> usize {
     let init_page = octo
@@ -40,10 +63,12 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
         .await?;
 
     let thirty_days_ago = Utc::now() - Duration::days(30);
-    let mut pr_count: usize = init_page.items.len();
+    let mut pr_count: usize = 0;
     let mut next_page = init_page.next.to_owned();
 
-    let mut count_valid_prs = |page: octocrab::Page<PullRequest>| -> Option<()> {
+    // given a page of PRs, count any valid PRs and stop iteration as soon as we surpass our date range of 30 days
+    let mut count_valid_prs = |page: octocrab::Page<PullRequest>| -> Option<Url> {
+        let copy_next = page.next.to_owned();
         let mut all_valid = true;
         for pr in page {
             if pr.created_at < thirty_days_ago {
@@ -54,15 +79,16 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
             }
         }
 
-        return if all_valid { Some(()) } else { None };
+        return if all_valid { copy_next } else { None };
     };
 
+    // run initial page of data through the counter; this might be the only page we have!
+    // note: this is set up this way b/c the `octo.get_page` different is called for all
+    // subsequent pages (rather than `octo.pulls()` which allows us all sorts of good specifications)
+    count_valid_prs(init_page);
+
     while let Some(page) = octo.get_page::<PullRequest>(&next_page).await? {
-        let copy_next = page.next.to_owned();
-        next_page = match count_valid_prs(page) {
-            Some(_) => copy_next,
-            _ => None,
-        }
+        next_page = count_valid_prs(page);
     }
 
     pr_count

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
                 pr_count += 1;
             } else {
                 all_valid = false;
-				break;
+                break;
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() {
     let rust_lang_org = octocrab.orgs("rust-lang");
     let repos: Vec<Repository> = all_repos(&&rust_lang_org).await?;
 
-    println!("#PR,\t\tREPO");
+    println!("#PR,\tREPO\n--------------------");
     for repo in &repos {
         let count_prs = count_pull_requests(&octocrab, &repo.name).await?;
         println!("{},\t{}", count_prs, repo.name);
@@ -50,12 +50,12 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
                 pr_count += 1;
             } else {
                 all_valid = false;
+				break;
             }
         }
 
         return if all_valid { Some(()) } else { None };
     };
-    // count_valid_prs(init_page);
 
     while let Some(page) = octo.get_page::<PullRequest>(&next_page).await? {
         let copy_next = page.next.to_owned();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
     let rust_lang_org = octocrab.orgs("rust-lang");
     let repos: Vec<Repository> = all_repos(&&rust_lang_org).await?;
 
-    println!("#PR,\tREPO\n--------------------");
+    println!("# PRs,\tREPO\n--------------------");
     for repo in &repos {
         let count_prs = count_pull_requests(&octocrab, &repo.name).await?;
         println!("{},\t{}", count_prs, repo.name);
@@ -28,14 +28,14 @@ async fn all_repos(org: &octocrab::orgs::OrgHandler<'_>) -> Vec<octocrab::models
     util::accumulate_pages(|page| org.list_repos().page(page).send()).await?
 }
 
-/// count the number of pull requests created in the last 30 days for the given repository within the [`rust-lang` github organization](https://github.com/rust-lang)
+/// count the number of pull requests created in the last 30 days for the given rust-lang repository within the [`rust-lang` GitHub Organization]
 ///
-/// ## Arguments
+/// # Arguments
 ///
-/// - `octo` — the instance of `octocrab::Octocrab` that should be used to make any GitHub queries
-/// - `repo_name` — The name of the repository (within GitHub Organization "rust-lang") to count pull-requests for
+/// - `octo` The instance of `octocrab::Octocrab` that should be used to make queries to GitHub API
+/// - `repo_name` — The name of the repository to count pull requests for. **Note:** repository should exist within the [`rust-lang` Github Organization]
 ///
-/// ## Example
+/// # Example
 ///
 /// ```
 /// use github-metrics;
@@ -46,8 +46,10 @@ async fn all_repos(org: &octocrab::orgs::OrgHandler<'_>) -> Vec<octocrab::models
 ///
 /// const num_pull_requests = github-metrics::count_pull_requests(octocrab_instance, String::from("rust"));
 ///
-/// println!("'rust-lang/rust' has had {} Pull Requests in the last 30 days!", num_pull_requests);
+/// println!("The 'rust-lang/rust' repo has had {} Pull Requests created in the last 30 days!", num_pull_requests);
 /// ```
+///
+/// [`rust-lang` GitHub Organization]: https://github.com/rust-lang
 #[throws]
 async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> usize {
     let mut page = octo
@@ -81,5 +83,5 @@ async fn count_pull_requests(octo: &octocrab::Octocrab, repo_name: &String) -> u
         }
     }
 
-    return pr_count;
+    pr_count
 }


### PR DESCRIPTION
# Description

Closes #1

Feature: output the number of PRs created in the last 30 days for each repository in the `rust-lang` organization alongside the title


## Points for Feedback

- repositories are doubling up... if you run this code, you'll see a long list of repos but they repeat at least twice. I don't know if this is a product of the `all_repos` function or whether it is an issue I introduced somewhere in this code
- output feels incredibly slow (to me). This may be a product of `println!()` macro calls within the loop, or it could be a result of the nature of the nested calls to `octocrab` that I make to get the pull request count. 
  - [from nikomatsakis](https://github-metrics.zulipchat.com/#narrow/stream/291433-general/topic/PR.20.238.20ready.20to.20review/near/241680336): Regarding performance, I would guess that it's a function of network requests, but we can measure that.
