### PR TITLE
fix: remove duplicate repo data

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ where
     F: Future<Output = Result<Page<T>, octocrab::Error>>,
 {
     let mut repos = vec![];
-    for page in 0_u32.. {
+    for page in 1_u32.. {
         let page = data(page).await?;
         let items_len = page.items.len();
         repos.extend(page.items);


### PR DESCRIPTION
# Description

- Fixes problems [RE: duplicated repositories](https://github-metrics.zulipchat.com/#narrow/stream/291433-general/topic/duplicated.20repos/near/241680603)

After looking at the output closer, I found that the repos are not actually duplicating all the way through, it's only duplicating the beginning chunk (from `rust` to `rust-mode` is the section that's duplicated)

Once I saw that I figured it was just duplicating a page of data. 
And sure enough, it happens  in `accumulate_pages` during the loop: `for page in 0_u32..` [src/util.rs#L11](https://github.com/nikomatsakis/github-metrics/blob/f69174e5c3056dd9f190896234de89b464093841/src/util.rs#L11).

The page at `0` and page at `1` are duplicates. The rest are not.