### PR TITLE
feat: refactor `count_pull_requests` to use GraphQL

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,10 +34,20 @@ async fn all_repos(org: &octocrab::orgs::OrgHandler<'_>) -> Vec<octocrab::models
     util::accumulate_pages(|page| org.list_repos().page(page).send()).await?
 }
 
+// ==================== GQL Query Structures =========================
+
 #[derive(Deserialize, Debug)]
 pub struct Response<T> {
     data: T,
     errors: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    end_cursor: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -53,6 +63,8 @@ struct Organization {
 #[derive(Deserialize, Debug)]
 struct Repositories {
     edges: Vec<Node>,
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
 }
 
 #[derive(Deserialize, Debug)]
@@ -65,32 +77,72 @@ struct RepoNode {
     name: String,
 }
 
+// ==================== GQL Query Functions =========================
+
+/// returns a list of relevant data (only) for each repositories under the given organization.
+///
+/// Note: Currently, the only repo data we're even using is its name. This will likely change over time.
+/// Mutate the query found in `metrics::get_query_str_all_repos` to add any relevant data necessary.
 #[throws]
 async fn all_repos_graphql(org: &str) -> Vec<String> {
     let octo = octocrab::instance();
-    let query_string = format!(
+
+    let mut query_string = get_query_str_all_repos(&org, None);
+    let mut repos: Vec<String> = vec![];
+
+    loop {
+        let response: Response<AllReposData> = octo.graphql(&query_string).await?;
+        let repos_data = response.data.organization.repositories;
+        repos.extend(
+            repos_data
+                .edges
+                .iter()
+                .map(|edge| edge.node.name.to_owned()),
+        );
+
+        if repos_data.page_info.has_next_page {
+            query_string = get_query_str_all_repos(&org, Some(&repos_data.page_info.end_cursor));
+        } else {
+            break;
+        }
+    }
+
+    repos
+}
+
+/// utility function used for pagination with the GraphQL "get all repositories for organization" query
+///
+/// # Arguments
+/// - `org` — The name of the GitHub Organization to retrieve all the repositories for
+/// - `after_cursor` — An optional cursor value to start at (provided by the `pageInfo` property in the previous page)
+///
+/// Feel free to explore in the [GitHub GraphQL Explorer]
+///
+/// [GitHub GraphQL Explorer]: https://docs.github.com/en/graphql/overview/explorer
+fn get_query_str_all_repos(org: &str, after_cursor: Option<&str>) -> String {
+    let after_clause = if let Some(cursor) = after_cursor {
+        format!(r#", after:"{}""#, cursor)
+    } else {
+        String::new()
+    };
+
+    format!(
         r#"query {{
             organization(login:"{org_name}"){{
-                repositories(first:100){{
+                repositories(first:100{after_clause}){{
                     edges {{
                         node {{
                             name
                         }}
                     }}
+                    pageInfo {{
+                        hasNextPage
+                        endCursor
+                    }}
                 }}
             }}
           }}"#,
         org_name = org,
-    );
-
-    let response: Response<AllReposData> = octo.graphql(&query_string).await?;
-
-    response
-        .data
-        .organization
-        .repositories
-        .edges
-        .iter()
-        .map(|node| node.node.name.to_owned())
-        .collect::<Vec<String>>()
+        after_clause = after_clause,
+    )
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -120,12 +120,6 @@ async fn all_repos_graphql(org: &str) -> Vec<String> {
 ///
 /// [GitHub GraphQL Explorer]: https://docs.github.com/en/graphql/overview/explorer
 fn get_query_str_all_repos(org: &str, after_cursor: Option<&str>) -> String {
-    let after_clause = if let Some(cursor) = after_cursor {
-        format!(r#", after:"{}""#, cursor)
-    } else {
-        String::new()
-    };
-
     format!(
         r#"query {{
             organization(login:"{org_name}"){{
@@ -143,6 +137,10 @@ fn get_query_str_all_repos(org: &str, after_cursor: Option<&str>) -> String {
             }}
           }}"#,
         org_name = org,
-        after_clause = after_clause,
+        after_clause = if let Some(cursor) = after_cursor {
+            format!(r#", after:"{}""#, cursor)
+        } else {
+            "".to_string()
+        },
     )
 }

--- a/src/metrics/list_repos.rs
+++ b/src/metrics/list_repos.rs
@@ -155,7 +155,15 @@ async fn count_pull_requests_graphql(org_name: &str, repo_name: &str) -> usize {
     let thirty_days_ago_str = chars.as_str();
 
     let query_string = format!(
-        "query {{ search(query:\"repo:{org_name}/{repo_name} is:pr created:>{thirty_days_ago}\", type:ISSUE, last:100) {{ issueCount }} }}",
+        r#"query {{
+            search(
+                query:"repo:{org_name}/{repo_name} is:pr created:>{thirty_days_ago}", 
+                type:ISSUE, 
+                last:100,
+            ) {{
+                issueCount
+            }}
+        }}"#,
         org_name=org_name,
         thirty_days_ago=thirty_days_ago_str,
         repo_name=repo_name

--- a/src/metrics/print.rs
+++ b/src/metrics/print.rs
@@ -12,7 +12,7 @@ impl Consumer for Print {
         column_names: Vec<String>,
     ) -> Result<(), String> {
         println!(
-            "#\t{}\t{}\n-----------------------------------",
+            "#\t{}\t{}\n------------------------------------------",
             column_names[1], column_names[0]
         );
         let mut count = 1;

--- a/src/metrics/print.rs
+++ b/src/metrics/print.rs
@@ -12,11 +12,13 @@ impl Consumer for Print {
         column_names: Vec<String>,
     ) -> Result<(), String> {
         println!(
-            "{}\t{}\n-----------------------------------",
+            "#\t{}\t{}\n-----------------------------------",
             column_names[1], column_names[0]
         );
+        let mut count = 1;
         while let Some(entry) = rx.recv().await {
-            println!("{}\t\t{}", &entry[1], &entry[0]);
+            println!("{}\t{}\t\t{}", count, &entry[1], &entry[0]);
+            count += 1;
         }
 
         Ok(())


### PR DESCRIPTION
# Description

This PR improves the speed of the `src/metrics/list_repos` producer by an incredible amount by simple shifting our `count_pull_requests` function to utilize a GraphQL call.

- [x] refactor 'count_pull_requests' function to utilize graphql query