### PR TITLE
Bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "graphql-introspection-query"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610aac641dbd2a457ad4cef34aa2827dae3f035fd214cb38c2d62d8543f3973f"
+checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
 dependencies = [
  "serde",
 ]
@@ -811,11 +811,10 @@ dependencies = [
 
 [[package]]
 name = "graphql_client"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bb4f09181e4f80018d01c612125b07e0156f3753bfac37055fe2a25e031ca8"
+checksum = "a9b58571cfc3cc42c3e8ff44fc6cfbb6c0dea17ed22d20f9d8f1efc4e8209a3f"
 dependencies = [
- "doc-comment",
  "graphql_query_derive",
  "serde",
  "serde_json",
@@ -823,11 +822,10 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e304c223c809b3bff4614018f8e6d9edb176b31d64ed9ea48b6ae8b1a03abb9"
+checksum = "b4bf9cd823359d74ad3d3ecf1afd4a975f4ff2f891cdf9a66744606daf52de8c"
 dependencies = [
- "failure",
  "graphql-introspection-query",
  "graphql-parser",
  "heck",
@@ -841,11 +839,10 @@ dependencies = [
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f6b14d5ce549227aa9e649cd9d36d008b91021275a8e0a67d71cef815adc2f"
+checksum = "e56b093bfda71de1da99758b036f4cc811fd2511c8a76f75680e9ffbd2bb4251"
 dependencies = [
- "failure",
  "graphql_client_codegen",
  "proc-macro2",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 toml = "0.5.8"
 async-trait = "0.1.50"
-graphql_client = "0.9.0"
+graphql_client = "0.10.0"
 log = "0.4"
 env_logger = "0.9"
 csv = "1.1"

--- a/src/metrics/repo_participants.rs
+++ b/src/metrics/repo_participants.rs
@@ -149,7 +149,7 @@ async fn pr_participants(
             // Extract PR author
             let mut author = None;
             if let Some(a) = pr.author {
-                if let pap::PrsAndParticipantsSearchEdgesNodeOnPullRequestAuthorOn::User(u) = a.on {
+                if let pap::PrsAndParticipantsSearchEdgesNodeOnPullRequestAuthor::User(u) = a {
                     author = Some(u.login);
                 }
             }
@@ -197,19 +197,17 @@ async fn pr_participants(
                 .inspect(|_| reviews_found += 1)
                 .flatten()
                 .flat_map(|n| n.author)
-                .flat_map(|a| {
-                    match a.on {
-                    pap::PrsAndParticipantsSearchEdgesNodeOnPullRequestReviewsNodesAuthorOn::User(
+                .flat_map(|a| match a {
+                    pap::PrsAndParticipantsSearchEdgesNodeOnPullRequestReviewsNodesAuthor::User(
                         u,
                     ) => Some(u.login),
                     _ => None,
-                }
                 })
                 .collect();
             for reviewer in reviewers {
                 // you don't count as a reviewer if you review your own PR
                 if !is_author(&reviewer) {
-                    counts.entry(reviewer).or_default().reviewed += 1;
+                    counts.entry(reviewer.to_string()).or_default().reviewed += 1;
                 }
             }
 
@@ -224,8 +222,7 @@ async fn pr_participants(
 
             // Count the number of PRs which a person has merged.
             if let Some(a) = pr.merged_by {
-                if let pap::PrsAndParticipantsSearchEdgesNodeOnPullRequestMergedByOn::User(u) = a.on
-                {
+                if let pap::PrsAndParticipantsSearchEdgesNodeOnPullRequestMergedBy::User(u) = a {
                     counts.entry(u.login).or_default().resolved += 1;
                 }
             }


### PR DESCRIPTION
These are mostly uninteresting, but something in the first commit fixes a crash:

```
    Finished release [optimized] target(s) in 0.05s
     Running `target/release/optopodi report data/2021-10-13`
    Updating crates.io index
thread 'tokio-runtime-worker' panicked at 'Unable to update registry: failed to fetch `https://github.com/rust-lang/crates.io-index`

Caused by:
    invalid version 0 on git_proxy_options; class=Invalid (3)', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/rust-playground-top-crates-0.1.0/src/lib.rs:228:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Failed to generate new report from directory data/2021-10-13

Caused by:
   0: Failed to parse Top Crates
   1: Failed to spawn blocking task
   2: panic
```